### PR TITLE
Fix: remove uniqueness constraint on phone number

### DIFF
--- a/members/forms.py
+++ b/members/forms.py
@@ -68,17 +68,17 @@ class RegistrationForm(forms.ModelForm):
             cleaned_phone = PhoneNumber.from_string(phone_str, region="KE")
 
             # For new registrations or if phone number is changing, check for uniqueness
-            if not self.instance.pk or (
-                self.instance.pk
-                and str(cleaned_phone) != str(self.instance.phone_number)
-            ):
-                # Check if phone number is already in use by another registration
-                existing = Registration.objects.filter(phone_number=cleaned_phone)
-                if self.instance.pk:
-                    existing = existing.exclude(pk=self.instance.pk)
-
-                if existing.exists():
-                    raise forms.ValidationError("This phone number is already in use.")
+            #if not self.instance.pk or (
+            #    self.instance.pk
+            #    and str(cleaned_phone) != str(self.instance.phone_number)
+            #):
+            #    # Check if phone number is already in use by another registration
+            #    existing = Registration.objects.filter(phone_number=cleaned_phone)
+            #    if self.instance.pk:
+            #        existing = existing.exclude(pk=self.instance.pk)
+#
+            #    if existing.exists():
+            #        raise forms.ValidationError("This phone number is already in use.")
 
             return cleaned_phone
 

--- a/members/models.py
+++ b/members/models.py
@@ -15,7 +15,6 @@ class Registration(models.Model):
         max_length=6, choices=[("Male", "Male"), ("Female", "Female")]
     )
     phone_number = PhoneNumberField(
-        unique=True,
         blank=True,
         null=True,
         region="KE",
@@ -33,7 +32,7 @@ class Registration(models.Model):
         max_length=3, choices=[("Yes", "Yes"), ("No", "No")]
     )
     join_whatsapp_group = models.CharField(
-        max_length=3, choices=[("Yes", "Yes"), ("No", "No")]
+        max_length=3, choices=[("Yes", "Yes"), ("No", "No"), ("nil", "nil")],
     )
     consent = models.CharField(max_length=3, choices=[("Yes", "Yes"), ("No", "No")])
     created_at = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
This pull request introduces changes to the `members` app, primarily focusing on relaxing phone number uniqueness constraints and adding a new option to the `join_whatsapp_group` field. These updates simplify validation logic and expand data flexibility.

### Changes to phone number validation and uniqueness:

* [`members/forms.py`](diffhunk://#diff-428d5855b8c944ae4be6c675632222f264ed3d985f17386570428299165f7debL71-R81): Commented out the validation logic in `clean_phone_number` that checks for phone number uniqueness during registration. This effectively removes the uniqueness check for phone numbers.
* [`members/models.py`](diffhunk://#diff-0dce376f49da7b12fb73aefc4914accd4bc363932bfd8bea979ee0e597e1a1f3L18): Removed the `unique=True` constraint from the `phone_number` field in the `Registration` model, allowing duplicate phone numbers in the database.

### Changes to field options:

* [`members/models.py`](diffhunk://#diff-0dce376f49da7b12fb73aefc4914accd4bc363932bfd8bea979ee0e597e1a1f3L36-R35): Added a new option, `"nil"`, to the `join_whatsapp_group` field in the `Registration` model to accommodate cases where no explicit choice is made.